### PR TITLE
Fix URL whitelist bypass and server-side validation issues

### DIFF
--- a/src/main/java/com/vinurl/net/ClientEvent.java
+++ b/src/main/java/com/vinurl/net/ClientEvent.java
@@ -24,9 +24,22 @@ public class ClientEvent {
 			BlockPos pos = message.pos();
 			String url = message.url();
 			boolean loop = message.loop();
-			String fileName = SoundManager.getFileName(url);
 
 			if (client.player == null || url.isEmpty()) {return;}
+
+			URI uri;
+
+			try {
+				uri = new URI(url);
+			} catch (Exception ignored) {
+				return;
+			}
+
+			String scheme = uri.getScheme();
+			String host = uri.getHost();
+			if (scheme == null || host == null) {return;}
+
+			String fileName = SoundManager.getFileName(url);
 
 			SoundManager.addSound(fileName, pos, loop);
 
@@ -41,7 +54,7 @@ public class ClientEvent {
 			}
 
 			if (CONFIG.downloadEnabled()) {
-				String baseURL = URI.create(url).getScheme() + "://" + URI.create(url).getHost();
+				String baseURL = scheme + "://" + host;
 
 				if (CONFIG.urlWhitelist().contains(baseURL)) {
 					SoundManager.downloadSound(url, fileName);

--- a/src/main/java/com/vinurl/net/ClientEvent.java
+++ b/src/main/java/com/vinurl/net/ClientEvent.java
@@ -43,7 +43,7 @@ public class ClientEvent {
 			if (CONFIG.downloadEnabled()) {
 				String baseURL = URI.create(url).getScheme() + "://" + URI.create(url).getHost();
 
-				if (CONFIG.urlWhitelist().stream().anyMatch(url::startsWith)) {
+				if (CONFIG.urlWhitelist().contains(baseURL)) {
 					SoundManager.downloadSound(url, fileName);
 					SoundManager.queueSound(fileName, pos);
 					return;

--- a/src/main/java/com/vinurl/net/ServerEvent.java
+++ b/src/main/java/com/vinurl/net/ServerEvent.java
@@ -42,7 +42,11 @@ public class ServerEvent {
 			String url;
 
 			try {
-				url = new URI(message.url()).toURL().toString();
+				URI uri = new URI(message.url());
+				if (uri.getHost() == null) {
+					throw new IllegalArgumentException("Missing host");
+				}
+				url = uri.toURL().toString();
 			} catch (Exception e) {
 				player.displayClientMessage(Component.translatable("message.vinurl.custom_record.url.invalid"), true);
 				return;

--- a/src/main/java/com/vinurl/net/ServerEvent.java
+++ b/src/main/java/com/vinurl/net/ServerEvent.java
@@ -19,6 +19,8 @@ import static com.vinurl.util.Constants.*;
 
 public class ServerEvent {
 	public static final int MAX_URL_LENGTH = 400;
+	public static final int MIN_DURATION = 0;
+	public static final int MAX_DURATION = 3600;
 
 	public static void register() {
 		NETWORK_CHANNEL.registerClientboundDeferred(ClientEvent.GUIRecord.class);
@@ -59,7 +61,7 @@ public class ServerEvent {
 
 			CompoundTag tag = new CompoundTag();
 			tag.put(URL_KEY, url);
-			tag.put(DURATION_KEY, message.duration());
+			tag.put(DURATION_KEY, Math.clamp(message.duration(), MIN_DURATION, MAX_DURATION));
 			tag.put(LOOP_KEY, message.loop());
 			tag.put(LOCK_KEY, message.lock());
 			stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));

--- a/src/main/java/com/vinurl/net/ServerEvent.java
+++ b/src/main/java/com/vinurl/net/ServerEvent.java
@@ -41,6 +41,12 @@ public class ServerEvent {
 				return;
 			}
 
+			CompoundTag existingTag = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
+			if (existingTag.get(LOCK_KEY)) {
+				player.displayClientMessage(Component.translatable("item.vinurl.custom_record.message.locked"), true);
+				return;
+			}
+
 			String url;
 
 			try {


### PR DESCRIPTION
Currently the URL whitelist since it was introduced in 1.4.0 has a flaw in its validation logic. The code computes `baseURL` but checks the original `url` using `startsWith()` against whitelist entries.

However, even if `baseURL` were used, `startsWith()` would only protect against userinfo bypasses such as `youtube.com@evil.com`, not subdomain spoofing where `youtube.com.evil.com` matches a whitelisted `youtube.com`.

Additionally, `URI.toURL()` accepts URLs such as `https:foobar.com`. In this case the URI has no authority and the `foobar.com` portion is parsed as the path, resulting in a `null` host. When played, this causes the client to display `https://null` in the whitelisting prompt.

The `SetURLRecord` message also relies only on client-side validation for disc lock status and duration bounds, which can be bypassed by a modified client.

This PR resolves these issues by validating URLs, requiring both a scheme and host, and performing an exact whitelist match on `scheme://host`. Server-side validation has also been added so locked discs cannot be modified and record duration is clamped to the allowed range (0-3600 seconds) per the client [disc_url_screen.xml](https://github.com/Plompi/VinURL/blob/0d9cb827959d939c0a8b45a648dfbcbf2a090a40/src/main/resources/assets/vinurl/owo_ui/disc_url_screen.xml#L76-L82).

Note: manually configured whitelist entries with trailing slashes (e.g. `https://example.com/`) will no longer match compared to the original logic.