### PR TITLE
deowoify VinURL

### DIFF
--- a/src/main/java/com/vinurl/api/VinURLSound.java
+++ b/src/main/java/com/vinurl/api/VinURLSound.java
@@ -1,5 +1,6 @@
 package com.vinurl.api;
 
+import com.vinurl.item.URLDisc;
 import com.vinurl.net.ClientEvent;
 
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -27,25 +28,25 @@ public class VinURLSound {
 
 	public static void playAt(ServerLevel level, ItemStack stack, BlockPos pos) {
 		send(stack, () -> playersInRange(level, pos, JUKEBOX_RANGE), (tag) ->
-			new ClientEvent.PlaySoundRecord(pos, -1, tag.get(URL_KEY))
+			new ClientEvent.PlaySoundRecord(pos, -1, URLDisc.DataWrapper.getUrl(tag))
 		);
 	}
 
 	public static void playFor(ServerLevel level, ItemStack stack, int entityID) {
 		send(stack, () -> playersInRange(level, entityID, JUKEBOX_RANGE), (tag) ->
-			new ClientEvent.PlaySoundRecord(null, entityID, tag.get(URL_KEY))
+			new ClientEvent.PlaySoundRecord(null, entityID, URLDisc.DataWrapper.getUrl(tag))
 		);
 	}
 
 	public static void stopAt(ServerLevel level, ItemStack stack, BlockPos pos, boolean cancelable) {
 		send(stack, () -> playersInRange(level, pos, INFINITE_RANGE), (tag) ->
-			new ClientEvent.StopSoundRecord(pos, -1, tag.get(URL_KEY), cancelable)
+			new ClientEvent.StopSoundRecord(pos, -1, URLDisc.DataWrapper.getUrl(tag), cancelable)
 		);
 	}
 
 	public static void stopFor(ServerLevel level, ItemStack stack, int entityID, boolean cancelable) {
 		send(stack, () -> playersInRange(level, entityID, INFINITE_RANGE), (tag) ->
-			new ClientEvent.StopSoundRecord(null, entityID, tag.get(URL_KEY), cancelable)
+			new ClientEvent.StopSoundRecord(null, entityID, URLDisc.DataWrapper.getUrl(tag), cancelable)
 		);
 	}
 

--- a/src/main/java/com/vinurl/api/VinURLSound.java
+++ b/src/main/java/com/vinurl/api/VinURLSound.java
@@ -1,9 +1,12 @@
 package com.vinurl.api;
 
 import com.vinurl.net.ClientEvent;
+
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
@@ -46,12 +49,12 @@ public class VinURLSound {
 		);
 	}
 
-	private static void send(ItemStack stack, Supplier<List<ServerPlayer>> players, Function<CompoundTag, Record> factory) {
+	private static void send(ItemStack stack, Supplier<List<ServerPlayer>> players, Function<CompoundTag, CustomPacketPayload> factory) {
 		if (!stack.is(CUSTOM_RECORD)) {return;}
 
 		CompoundTag tag = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
 		for (ServerPlayer player : players.get()) {
-			NETWORK_CHANNEL.serverHandle(player).send(factory.apply(tag));
+			ServerPlayNetworking.send(player, factory.apply(tag));
 		}
 	}
 

--- a/src/main/java/com/vinurl/client/VinURLClient.java
+++ b/src/main/java/com/vinurl/client/VinURLClient.java
@@ -3,6 +3,7 @@ package com.vinurl.client;
 import com.vinurl.cmd.Commands;
 import com.vinurl.exe.Executable;
 import com.vinurl.gui.ProgressOverlay;
+import com.vinurl.item.URLDisc;
 import com.vinurl.net.ClientEvent;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
@@ -48,8 +49,8 @@ public class VinURLClient implements ClientModInitializer {
 			lines.add(Component.translatable("itemGroup.tools").withStyle(ChatFormatting.BLUE));
 
 			if (CONFIG.showDescription()) {
-				String description = SoundManager.getDescription(SoundManager.getFileName(tag.get(URL_KEY)));
-				String locked = tag.get(LOCK_KEY) ? "🔒 " : "";
+				String description = SoundManager.getDescription(SoundManager.getFileName(URLDisc.DataWrapper.getUrl(tag)));
+				String locked = URLDisc.DataWrapper.getLock(tag) ? "🔒 " : "";
 				lines.add(Component.literal(locked + description).withStyle(ChatFormatting.GRAY));
 			}
 		});

--- a/src/main/java/com/vinurl/gui/URLDiscScreen.java
+++ b/src/main/java/com/vinurl/gui/URLDiscScreen.java
@@ -9,6 +9,7 @@ import io.wispforest.owo.ui.component.*;
 import io.wispforest.owo.ui.container.StackLayout;
 import io.wispforest.owo.ui.core.PositionedRectangle;
 import io.wispforest.owo.ui.util.NinePatchTexture;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.network.chat.Component;
@@ -112,7 +113,7 @@ public class URLDiscScreen extends BaseUIModelScreen<StackLayout> {
 	@Override
 	public boolean keyPressed(KeyEvent input) {
 		if (input.key() == GLFW.GLFW_KEY_ESCAPE || input.key() == GLFW.GLFW_KEY_ENTER) {
-			NETWORK_CHANNEL.clientHandle().send(new ServerEvent.SetURLRecord(url, duration, lock));
+			ClientPlayNetworking.send(new ServerEvent.SetURLRecord(url, duration, lock));
 			this.onClose();
 			return true;
 		}

--- a/src/main/java/com/vinurl/gui/URLDiscScreen.java
+++ b/src/main/java/com/vinurl/gui/URLDiscScreen.java
@@ -1,136 +1,89 @@
 package com.vinurl.gui;
 
-import com.vinurl.client.SoundManager;
-import com.vinurl.client.VinURLClient;
-import com.vinurl.exe.Executable;
-import com.vinurl.net.ServerEvent;
-import io.wispforest.owo.ui.base.BaseUIModelScreen;
-import io.wispforest.owo.ui.component.*;
-import io.wispforest.owo.ui.container.StackLayout;
-import io.wispforest.owo.ui.core.PositionedRectangle;
-import io.wispforest.owo.ui.util.NinePatchTexture;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
-import net.minecraft.client.input.KeyEvent;
-import net.minecraft.network.chat.Component;
-import net.minecraft.resources.Identifier;
+import static com.vinurl.net.ServerEvent.MAX_URL_LENGTH;
+
+import org.joml.Vector2i;
 import org.lwjgl.glfw.GLFW;
 
-import static com.vinurl.client.VinURLClient.CLIENT;
-import static com.vinurl.util.Constants.*;
+import com.vinurl.net.ServerEvent;
 
-public class URLDiscScreen extends BaseUIModelScreen<StackLayout> {
-	private String url;
-	private boolean lock;
-	private boolean sliderDragged;
-	private boolean simulate;
-	private int duration;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.LockIconButton;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.Component;
 
-	private final ButtonComponent.Renderer SIMULATE_BUTTON_TEXTURE = (matrices, button, delta) -> {
-		Identifier texture = !simulate ? (button.active && button.isHovered() ?
-			SIMULATE_BUTTON_HOVER_ID :
-			SIMULATE_BUTTON_ID) :
-			SIMULATE_BUTTON_DISABLED_ID;
-		NinePatchTexture.draw(texture, matrices, button.getX(), button.getY(), button.getWidth(), button.getHeight());
-	};
+public class URLDiscScreen extends Screen {
+	private static final int PADDING = 5;
 
-	private final ButtonComponent.Renderer LOCK_BUTTON_TEXTURE = (matrices, button, delta) -> {
-		Identifier texture = lock ?
-			LOCK_BUTTON_ID :
-			LOCK_BUTTON_DISABLED_ID;
-		NinePatchTexture.draw(texture, matrices, button.getX(), button.getY(), button.getWidth(), button.getHeight());
-	};
+	private static record InitialData(String url, int duration) {
+	}
 
-	public URLDiscScreen(String defaultURL, int defaultDuration) {
-		super(StackLayout.class, DataSource.asset(URL_DISC_SCREEN_ID));
-		this.url = defaultURL;
-		this.duration = defaultDuration;
+	private final InitialData initialData;
+
+	private EditBox urlTextbox;
+	private LockIconButton lockButton;
+
+	public URLDiscScreen(String url, int duration) {
+		this(new InitialData(url, duration));
+	}
+
+	private URLDiscScreen(InitialData data) {
+		super(Component.literal("URL Disc Screen"));
+		this.initialData = data;
 	}
 
 	@Override
-	protected void build(StackLayout stackLayout) {
-		LabelComponent placeholderLabel = stackLayout.childById(LabelComponent.class, "placeholder_label");
-		TextBoxComponent urlTextbox = stackLayout.childById(TextBoxComponent.class, "url_textbox");
-		SlimSliderComponent durationSlider = stackLayout.childById(SlimSliderComponent.class, "duration_slider");
-		ButtonComponent lockButton = stackLayout.childById(ButtonComponent.class, "lock_button");
-		ButtonComponent simulateButton = stackLayout.childById(ButtonComponent.class, "simulate_button");
-		TextureComponent textFieldTexture = stackLayout.childById(TextureComponent.class, "text_field_disabled");
+	protected void init() {
+		Vector2i center = new Vector2i(width / 2, height / 2);
 
-		durationSlider.value(duration);
-		durationSlider.tooltipSupplier((slider) -> Component.literal("%02d:%02d".formatted(duration / 60, duration % 60)));
-		durationSlider.mouseDown().subscribe((click, doubled) -> {
-			sliderDragged = true;
-			lockButton.active = simulateButton.active = false;
-			return true;
-		});
-		durationSlider.mouseUp().subscribe((click) -> {
-			sliderDragged = false;
-			lockButton.active = simulateButton.active = true;
-			return true;
-		});
-		durationSlider.onChanged().subscribe((newValue) -> duration = (int) newValue);
-		durationSlider.mouseScroll().subscribe((mouseX, mouseY, amount) -> {
-			durationSlider.value(Math.clamp(durationSlider.value() + amount, durationSlider.min(), durationSlider.max()));
-			return true;
-		});
+		{
+			Component urlPlaceholder = Component.translatable("gui.vinurl.textfield.placeholder");
 
-		lockButton.renderer(LOCK_BUTTON_TEXTURE);
-		lockButton.onPress((button) -> lock = !lock);
+			Vector2i size = new Vector2i(240, 20);
+			urlTextbox = new EditBox(
+					font,
+					center.x - (size.x / 2), center.y,
+					size.x, size.y,
+					// no proper string for the edit box's narration atm
+					// so this'll do until then
+					urlPlaceholder);
 
-		simulateButton.renderer(SIMULATE_BUTTON_TEXTURE);
-		simulateButton.onPress((button) -> {
-			if (simulate) {return;}
-			simulate = true;
-			button.tooltip(Component.translatable("gui.vinurl.button.duration.tooltip.calculating"));
-			Executable.executeCommand(
-				SoundManager.getFileName(url) + "/duration", Executable.YT_DLP.getCommandLine().addArguments(new String[] {
-					url, "--print", "DURATION: %(duration)d", "--no-playlist",
-                    "--js-runtimes", "deno:" + Executable.DENO.FILE_PATH
-				}, false).addArguments(VinURLClient.CONFIG.parameters())
-			).subscribe("duration")
-				.onOutput((output) -> {
-					String type = output.substring(0, output.indexOf(':') + 1);
-					String message = output.substring(type.length()).trim();
+			urlTextbox.setMaxLength(MAX_URL_LENGTH);
+			urlTextbox.setHint(urlPlaceholder);
 
-					switch (type) {
-						case "DURATION:" -> durationSlider.value(Integer.parseInt(message));
-						case "WARNING:" -> LOGGER.warn(message);
-						case "ERROR:" -> LOGGER.error(message);
-						default -> LOGGER.info(output);
-					}
-				})
-				.onError((error) -> {button.tooltip(Component.translatable("gui.vinurl.button.duration.tooltip")); simulate = false;})
-				.onComplete(() -> {button.tooltip(Component.translatable("gui.vinurl.button.duration.tooltip")); simulate = false;})
-			.start();
-		});
+			urlTextbox.setValue(initialData.url);
 
-		urlTextbox.onChanged().subscribe((text) -> placeholderLabel.text(Component.literal((url = text).isEmpty() ? "URL" : "")));
-		urlTextbox.text(url);
-		urlTextbox.focusLost().subscribe(() -> textFieldTexture.visibleArea(PositionedRectangle.of(0, 0, 110, 16)));
-		urlTextbox.focusGained().subscribe((source) -> textFieldTexture.visibleArea(PositionedRectangle.of(0, 0, 0, 0)));
+			addRenderableWidget(urlTextbox);
+		}
+
+		{
+			lockButton = new LockIconButton(
+					center.x + (urlTextbox.getWidth() / 2) + PADDING, center.y,
+					_ -> lockButton.setLocked(!lockButton.isLocked()));
+
+			lockButton.setTooltip(Tooltip.create(Component.translatable("gui.vinurl.button.lock")));
+
+			addRenderableWidget(lockButton);
+		}
 	}
 
 	@Override
 	public boolean keyPressed(KeyEvent input) {
 		if (input.key() == GLFW.GLFW_KEY_ESCAPE || input.key() == GLFW.GLFW_KEY_ENTER) {
+			String url = urlTextbox.getValue();
+			// TODO: implement UI for duration
+			int duration = 60;
+			boolean lock = lockButton.isLocked();
+
 			ClientPlayNetworking.send(new ServerEvent.SetURLRecord(url, duration, lock));
 			this.onClose();
 			return true;
 		}
+
 		return super.keyPressed(input);
-	}
-
-	@Override
-	public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
-		super.extractRenderState(context, mouseX, mouseY, delta);
-
-		if (sliderDragged) {
-			context.setTooltipForNextFrame(
-				CLIENT.font,
-				Component.literal("%02d:%02d".formatted(duration / 60, duration % 60)),
-				mouseX, mouseY
-			);
-		}
 	}
 
 	@Override

--- a/src/main/java/com/vinurl/item/URLDisc.java
+++ b/src/main/java/com/vinurl/item/URLDisc.java
@@ -1,9 +1,12 @@
 package com.vinurl.item;
 
 import com.vinurl.net.ClientEvent;
+
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -31,7 +34,7 @@ public class URLDisc extends Item {
 		if (!level.isClientSide()) {
 			CompoundTag tag = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
 			if (!tag.get(LOCK_KEY)) {
-				NETWORK_CHANNEL.serverHandle(player).send(new ClientEvent.GUIRecord(tag.get(URL_KEY), tag.get(DURATION_KEY)));
+				ServerPlayNetworking.send((ServerPlayer) player, new ClientEvent.GUIRecord(tag.get(URL_KEY), tag.get(DURATION_KEY)));
 			} else {
 				player.sendOverlayMessage(Component.translatable("item.vinurl.custom_record.message.locked"));
 			}

--- a/src/main/java/com/vinurl/item/URLDisc.java
+++ b/src/main/java/com/vinurl/item/URLDisc.java
@@ -5,6 +5,7 @@ import com.vinurl.net.ClientEvent;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.StringTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
@@ -28,13 +29,47 @@ public class URLDisc extends Item {
 			.setId(ITEM_KEY));
 	}
 
+	public static final class DataWrapper {
+		public static final String URL_KEY = "music_url";
+		public static final String LOCK_KEY = "lock";
+		public static final String DURATION_KEY = "duration";
+
+		public static void putUrl(CompoundTag tag, String url) {
+			tag.put(URL_KEY, StringTag.valueOf(url));
+		}
+
+		public static void putLock(CompoundTag tag, boolean lock) {
+			tag.putBoolean(LOCK_KEY, lock);
+		}
+
+		public static void putDuration(CompoundTag tag, int duration) {
+			tag.putInt(DURATION_KEY, duration);
+		}
+
+		public static boolean hasDuration(CompoundTag tag) {
+			return tag.getInt(DURATION_KEY).isPresent();
+		}
+
+		public static String getUrl(CompoundTag tag) {
+			return tag.getStringOr(URL_KEY, "");
+		}
+
+		public static boolean getLock(CompoundTag tag) {
+			return tag.getBooleanOr(LOCK_KEY, false);
+		}
+
+		public static int getDuration(CompoundTag tag) {
+			return tag.getIntOr(DURATION_KEY, 0);
+		}
+	}
+
 	@Override
 	public InteractionResult use(Level level, Player player, InteractionHand hand) {
 		ItemStack stack = player.getItemInHand(hand);
 		if (!level.isClientSide()) {
 			CompoundTag tag = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
-			if (!tag.get(LOCK_KEY)) {
-				ServerPlayNetworking.send((ServerPlayer) player, new ClientEvent.GUIRecord(tag.get(URL_KEY), tag.get(DURATION_KEY)));
+			if (!DataWrapper.getLock(tag)) {
+				ServerPlayNetworking.send((ServerPlayer) player, new ClientEvent.GUIRecord(DataWrapper.getUrl(tag), DataWrapper.getDuration(tag)));
 			} else {
 				player.sendOverlayMessage(Component.translatable("item.vinurl.custom_record.message.locked"));
 			}

--- a/src/main/java/com/vinurl/mixin/JukeboxMixin.java
+++ b/src/main/java/com/vinurl/mixin/JukeboxMixin.java
@@ -1,6 +1,8 @@
 package com.vinurl.mixin;
 
 import com.vinurl.api.VinURLSound;
+import com.vinurl.item.URLDisc;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -18,8 +20,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import static com.vinurl.util.Constants.DURATION_KEY;
 
 @Mixin(JukeboxBlockEntity.class)
 public abstract class JukeboxMixin extends BlockEntity {
@@ -53,7 +53,7 @@ public abstract class JukeboxMixin extends BlockEntity {
 		if (level == null || level.isClientSide()) {return;}
 		CompoundTag tag = blockEntity.getTheItem().getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
 		JukeboxSongPlayer manager = blockEntity.getSongPlayer();
-		if (tag.has(DURATION_KEY) && manager.getTicksSinceSongStarted() > tag.get(DURATION_KEY) * 20L) {
+		if (URLDisc.DataWrapper.hasDuration(tag) && manager.getTicksSinceSongStarted() > URLDisc.DataWrapper.getDuration(tag) * 20L) {
 			manager.stop(level, state);
 			VinURLSound.stopAt((ServerLevel) level, blockEntity.getTheItem(), pos, false);
 		}

--- a/src/main/java/com/vinurl/net/ClientEvent.java
+++ b/src/main/java/com/vinurl/net/ClientEvent.java
@@ -21,7 +21,6 @@ import net.minecraft.resources.Identifier;
 
 import static com.vinurl.client.VinURLClient.CONFIG;
 import static com.vinurl.util.Constants.MOD_ID;
-import static com.vinurl.util.Constants.NETWORK_CHANNEL;
 
 public class ClientEvent {
 

--- a/src/main/java/com/vinurl/net/ClientEvent.java
+++ b/src/main/java/com/vinurl/net/ClientEvent.java
@@ -5,22 +5,34 @@ import com.vinurl.client.KeyListener;
 import com.vinurl.client.SoundManager;
 import com.vinurl.exe.Executable;
 import com.vinurl.gui.URLDiscScreen;
+import com.vinurl.util.Constants;
 import com.vinurl.util.Url;
-import io.wispforest.endec.annotations.IsNullable;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
 
 import static com.vinurl.client.VinURLClient.CONFIG;
+import static com.vinurl.util.Constants.MOD_ID;
 import static com.vinurl.util.Constants.NETWORK_CHANNEL;
 
 public class ClientEvent {
 
 	public static void register() {
+		PayloadTypeRegistry.clientboundPlay().register(GUIRecord.TYPE, GUIRecord.CODEC);
+		PayloadTypeRegistry.clientboundPlay().register(PlaySoundRecord.TYPE, PlaySoundRecord.CODEC);
+		PayloadTypeRegistry.clientboundPlay().register(StopSoundRecord.TYPE, StopSoundRecord.CODEC);
+
 		// Client event for playing sounds
-		NETWORK_CHANNEL.registerClientbound(PlaySoundRecord.class, (message, access) -> {
-			Minecraft client = access.runtime();
+		ClientPlayNetworking.registerGlobalReceiver(PlaySoundRecord.TYPE, (message, access) -> {
+			Minecraft client = access.client();
 			BlockPos pos = message.pos();
 			int entityID = message.entityID();
 			Url url = Url.parse(message.url());
@@ -71,7 +83,7 @@ public class ClientEvent {
 		});
 
 		// Client event for stopping sounds
-		NETWORK_CHANNEL.registerClientbound(StopSoundRecord.class, (message, access) -> {
+		ClientPlayNetworking.registerGlobalReceiver(StopSoundRecord.TYPE, (message, access) -> {
 			BlockPos pos = message.pos();
 			int entityID = message.entityID();
 			boolean cancel = message.cancel();
@@ -82,17 +94,71 @@ public class ClientEvent {
 		});
 
 		// Client event to open record ui
-		NETWORK_CHANNEL.registerClientbound(GUIRecord.class, (message, access) -> {
+		ClientPlayNetworking.registerGlobalReceiver(GUIRecord.TYPE, (message, access) -> {
 			String url = message.url();
 			int duration = message.duration();
 
-			access.runtime().setScreen(new URLDiscScreen(url, duration));
+			access.client().setScreen(new URLDiscScreen(url, duration));
 		});
 	}
 
-	public record PlaySoundRecord(@IsNullable(mayOmitField = false) BlockPos pos, int entityID, String url) {}
+	public record PlaySoundRecord(
+			BlockPos pos,
+			int entityID,
+			String url) implements CustomPacketPayload {
+		public static final Identifier IDENTIFIER = Identifier.fromNamespaceAndPath(
+				MOD_ID,
+				"play_sound_record");
 
-	public record StopSoundRecord(@IsNullable(mayOmitField = false) BlockPos pos, int entityID, String url, boolean cancel) {}
+		public static final CustomPacketPayload.Type<PlaySoundRecord> TYPE = new CustomPacketPayload.Type<>(IDENTIFIER);
 
-	public record GUIRecord(String url, int duration) {}
+		public static final StreamCodec<RegistryFriendlyByteBuf, PlaySoundRecord> CODEC = StreamCodec.composite(
+				BlockPos.STREAM_CODEC, PlaySoundRecord::pos,
+				ByteBufCodecs.INT, PlaySoundRecord::entityID,
+				ByteBufCodecs.STRING_UTF8, PlaySoundRecord::url,
+				PlaySoundRecord::new);
+
+		@Override
+		public Type<? extends CustomPacketPayload> type() {
+			return TYPE;
+		}
+	}
+
+	public record StopSoundRecord(
+			BlockPos pos,
+			int entityID,
+			String url,
+			boolean cancel) implements CustomPacketPayload {
+		public static final Identifier IDENTIFIER = Identifier.fromNamespaceAndPath(MOD_ID, "stop_sound_record");
+
+		public static final CustomPacketPayload.Type<StopSoundRecord> TYPE = new CustomPacketPayload.Type<>(IDENTIFIER);
+
+		public static final StreamCodec<RegistryFriendlyByteBuf, StopSoundRecord> CODEC = StreamCodec.composite(
+				BlockPos.STREAM_CODEC, StopSoundRecord::pos,
+				ByteBufCodecs.INT, StopSoundRecord::entityID,
+				ByteBufCodecs.STRING_UTF8, StopSoundRecord::url,
+				ByteBufCodecs.BOOL, StopSoundRecord::cancel,
+				StopSoundRecord::new);
+
+		@Override
+		public Type<? extends CustomPacketPayload> type() {
+			return TYPE;
+		}
+	}
+
+	public record GUIRecord(String url, int duration) implements CustomPacketPayload {
+		public static final Identifier IDENTIFIER = Identifier.fromNamespaceAndPath(MOD_ID, "gui_record");
+
+		public static final CustomPacketPayload.Type<GUIRecord> TYPE = new CustomPacketPayload.Type<>(IDENTIFIER);
+
+		public static final StreamCodec<RegistryFriendlyByteBuf, GUIRecord> CODEC = StreamCodec.composite(
+				ByteBufCodecs.STRING_UTF8, GUIRecord::url,
+				ByteBufCodecs.INT, GUIRecord::duration,
+				GUIRecord::new);
+
+		@Override
+		public Type<? extends CustomPacketPayload> type() {
+			return TYPE;
+		}
+	}
 }

--- a/src/main/java/com/vinurl/net/ServerEvent.java
+++ b/src/main/java/com/vinurl/net/ServerEvent.java
@@ -23,9 +23,6 @@ public class ServerEvent {
 	public static final int MAX_DURATION = 3600;
 
 	public static void register() {
-		NETWORK_CHANNEL.registerClientboundDeferred(ClientEvent.GUIRecord.class);
-		NETWORK_CHANNEL.registerClientboundDeferred(ClientEvent.PlaySoundRecord.class);
-		NETWORK_CHANNEL.registerClientboundDeferred(ClientEvent.StopSoundRecord.class);
 
 		// Server event handler for setting the URL on the custom record
 		NETWORK_CHANNEL.registerServerbound(SetURLRecord.class, (message, access) -> {

--- a/src/main/java/com/vinurl/net/ServerEvent.java
+++ b/src/main/java/com/vinurl/net/ServerEvent.java
@@ -1,5 +1,6 @@
 package com.vinurl.net;
 
+import com.vinurl.item.URLDisc;
 import com.vinurl.util.Url;
 
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
@@ -48,7 +49,7 @@ public class ServerEvent {
 			}
 
 			CompoundTag tag = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
-			if (tag.get(LOCK_KEY)) {
+			if (URLDisc.DataWrapper.getLock(tag)) {
 				player.sendOverlayMessage(Component.translatable("item.vinurl.custom_record.message.locked"));
 				return;
 			}
@@ -69,9 +70,9 @@ public class ServerEvent {
 				return;
 			}
 
-			tag.put(URL_KEY, url.toString());
-			tag.put(DURATION_KEY, message.duration());
-			tag.put(LOCK_KEY, message.lock());
+			URLDisc.DataWrapper.putUrl(tag, url.toString());
+			URLDisc.DataWrapper.putDuration(tag, message.duration());
+			URLDisc.DataWrapper.putLock(tag, message.lock());
 			stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
 
 			player.level().playSound(null, player, SoundEvents.VILLAGER_WORK_CARTOGRAPHER, SoundSource.MASTER, 1.0f, 1.0f);

--- a/src/main/java/com/vinurl/net/ServerEvent.java
+++ b/src/main/java/com/vinurl/net/ServerEvent.java
@@ -1,9 +1,17 @@
 package com.vinurl.net;
 
 import com.vinurl.util.Url;
+
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -23,9 +31,10 @@ public class ServerEvent {
 	public static final int MAX_DURATION = 3600;
 
 	public static void register() {
+		PayloadTypeRegistry.serverboundPlay().register(SetURLRecord.TYPE, SetURLRecord.CODEC);
 
 		// Server event handler for setting the URL on the custom record
-		NETWORK_CHANNEL.registerServerbound(SetURLRecord.class, (message, access) -> {
+		ServerPlayNetworking.registerGlobalReceiver(SetURLRecord.TYPE, (message, access) -> {
 			Player player = access.player();
 			ItemStack stack = Stream.of(InteractionHand.values())
 				.map(player::getItemInHand)
@@ -69,5 +78,20 @@ public class ServerEvent {
 		});
 	}
 
-	public record SetURLRecord(String url, int duration, boolean lock) {}
+	public record SetURLRecord(String url, int duration, boolean lock) implements CustomPacketPayload {
+		public static final Identifier IDENTIFIER = Identifier.fromNamespaceAndPath(MOD_ID, "set_url_record");
+
+		public static final CustomPacketPayload.Type<SetURLRecord> TYPE = new CustomPacketPayload.Type<>(IDENTIFIER);
+
+		public static final StreamCodec<RegistryFriendlyByteBuf, SetURLRecord> CODEC = StreamCodec.composite(
+				ByteBufCodecs.STRING_UTF8, SetURLRecord::url,
+				ByteBufCodecs.INT, SetURLRecord::duration,
+				ByteBufCodecs.BOOL, SetURLRecord::lock,
+				SetURLRecord::new);
+
+		@Override
+		public Type<? extends CustomPacketPayload> type() {
+			return TYPE;
+		}
+	}
 }

--- a/src/main/java/com/vinurl/util/Constants.java
+++ b/src/main/java/com/vinurl/util/Constants.java
@@ -33,9 +33,4 @@ public class Constants {
 	public static final Identifier LOCK_BUTTON_DISABLED_ID = Identifier.fromNamespaceAndPath(MOD_ID, "lock_button_disabled");
 	public static final ResourceKey<JukeboxSong> SONG_KEY = ResourceKey.create(Registries.JUKEBOX_SONG, PLACEHOLDER_SOUND_ID);
 	public static final ResourceKey<Item> ITEM_KEY = ResourceKey.create(Registries.ITEM, CUSTOM_RECORD_ID);
-
-	//networking
-	public static final KeyedEndec<String> URL_KEY = new KeyedEndec<>("music_url", Endec.STRING, "");
-	public static final KeyedEndec<Boolean> LOCK_KEY = new KeyedEndec<>("lock", Endec.BOOLEAN, false);
-	public static final KeyedEndec<Integer> DURATION_KEY = new KeyedEndec<>("duration", Endec.INT, 0);
 }

--- a/src/main/java/com/vinurl/util/Constants.java
+++ b/src/main/java/com/vinurl/util/Constants.java
@@ -1,7 +1,5 @@
 package com.vinurl.util;
 
-import io.wispforest.endec.Endec;
-import io.wispforest.endec.impl.KeyedEndec;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
@@ -25,12 +23,14 @@ public class Constants {
 	public static final Identifier KEY_MAPPING_ID = Identifier.fromNamespaceAndPath(MOD_ID, "mapping");
 	public static final Identifier NETWORK_ID = Identifier.fromNamespaceAndPath(MOD_ID, "network_channel");
 	public static final Identifier PROGRESS_HUD_ID = Identifier.fromNamespaceAndPath(MOD_ID, "progress_hud");
-	public static final Identifier URL_DISC_SCREEN_ID = Identifier.fromNamespaceAndPath(MOD_ID, "disc_url_screen");
+	// TODO: remove owo_ui files
+	// public static final Identifier URL_DISC_SCREEN_ID = Identifier.fromNamespaceAndPath(MOD_ID, "disc_url_screen");
 	public static final Identifier SIMULATE_BUTTON_ID = Identifier.fromNamespaceAndPath(MOD_ID, "simulate_button");
 	public static final Identifier SIMULATE_BUTTON_HOVER_ID = Identifier.fromNamespaceAndPath(MOD_ID, "simulate_button_hovered");
 	public static final Identifier SIMULATE_BUTTON_DISABLED_ID = Identifier.fromNamespaceAndPath(MOD_ID, "simulate_button_disabled");
-	public static final Identifier LOCK_BUTTON_ID = Identifier.fromNamespaceAndPath(MOD_ID, "lock_button");
-	public static final Identifier LOCK_BUTTON_DISABLED_ID = Identifier.fromNamespaceAndPath(MOD_ID, "lock_button_disabled");
+	// TODO: remove lock button sprites?
+	// public static final Identifier LOCK_BUTTON_ID = Identifier.fromNamespaceAndPath(MOD_ID, "lock_button");
+	// public static final Identifier LOCK_BUTTON_DISABLED_ID = Identifier.fromNamespaceAndPath(MOD_ID, "lock_button_disabled");
 	public static final ResourceKey<JukeboxSong> SONG_KEY = ResourceKey.create(Registries.JUKEBOX_SONG, PLACEHOLDER_SOUND_ID);
 	public static final ResourceKey<Item> ITEM_KEY = ResourceKey.create(Registries.ITEM, CUSTOM_RECORD_ID);
 }

--- a/src/main/java/com/vinurl/util/Constants.java
+++ b/src/main/java/com/vinurl/util/Constants.java
@@ -2,7 +2,6 @@ package com.vinurl.util;
 
 import io.wispforest.endec.Endec;
 import io.wispforest.endec.impl.KeyedEndec;
-import io.wispforest.owo.network.OwoNetChannel;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
@@ -36,7 +35,6 @@ public class Constants {
 	public static final ResourceKey<Item> ITEM_KEY = ResourceKey.create(Registries.ITEM, CUSTOM_RECORD_ID);
 
 	//networking
-	public static final OwoNetChannel NETWORK_CHANNEL = OwoNetChannel.create(NETWORK_ID);
 	public static final KeyedEndec<String> URL_KEY = new KeyedEndec<>("music_url", Endec.STRING, "");
 	public static final KeyedEndec<Boolean> LOCK_KEY = new KeyedEndec<>("lock", Endec.BOOLEAN, false);
 	public static final KeyedEndec<Integer> DURATION_KEY = new KeyedEndec<>("duration", Endec.INT, 0);


### PR DESCRIPTION
While owo-lib is great library it has a history of sometimes taking ages to update to new versions. While many library mods update day or within a week, owo-lib took about 2 months for 1.21.11 and has taken over about two months for 26.2 while still lacking an actual release. Compared to the owo-lib updates, VinURL itself generally doesn't need many changes for game updates. The goal of these changes would be to replace owo-lib with either Mojang systems (such as for networking & data) or libraries with faster release cycles (such as for configuration & UI).

It looks like owo-lib is currently used for the following:
- [x] Networking
  - Networking with Mojang's `CustomPacketPayload`s is thankfully quite simple and sending the events changes are quite small
  - For serverbound events
    - `NETWORK_CHANNEL.serverHandle(player).send(factory.apply(tag)) -> ServerPlayNetworking.send(player, factory.apply(tag))`
  - For clientbound events
    - `NETWORK_CHANNEL.clientHandle().send(new ServerEvent.SetURLRecord(url, duration, lock)) -> ClientPlayNetworking.send(new ServerEvent.SetURLRecord(url, duration, lock))`
    - Registering receivers is also essentially the same
    - The real drawback to the networking changes is that rather than owo-lib creating Endecs for us we have to manually write boilerplate for each `CustomPacketPayload`, for example `PlaySoundRecord`:
    ```java
    // with owo
    public record PlaySoundRecord(@IsNullable(mayOmitField = false) BlockPos pos, int entityID, String url) {}      
    ```
    ```java
    // with `CustomPacketPayload`
    public record PlaySoundRecord(
		    BlockPos pos,
		    int entityID,
		    String url) implements CustomPacketPayload {
	    public static final Identifier IDENTIFIER = Identifier.fromNamespaceAndPath(
			    MOD_ID,
			    "play_sound_record");
                                                                                                                         
	    public static final CustomPacketPayload.Type<PlaySoundRecord> TYPE = new CustomPacketPayload.Type<>(IDENTIFIER);
                                                                                                                         
	    public static final StreamCodec<RegistryFriendlyByteBuf, PlaySoundRecord> CODEC = StreamCodec.composite(
			    BlockPos.STREAM_CODEC, PlaySoundRecord::pos,
			    ByteBufCodecs.INT, PlaySoundRecord::entityID,
			    ByteBufCodecs.STRING_UTF8, PlaySoundRecord::url,
			    PlaySoundRecord::new);
                                                                                                                         
	    @Override
	    public Type<? extends CustomPacketPayload> type() {
		    return TYPE;
	    }
    }
    ```
- [ ] Configuration (owo-config)
  - I will try to make this not break existing configs if possible but I'm not particularly concerned about config breakage if it's not feasible as they're quite simple and all client-side
  - I will fill this out with possible libraries and their drawbacks after looking at them harder but tl;dr I'd like your opinion before working on anything
- [ ] `URLDiscScreen` (owo-ui)
  - I haven't really looked into how to do this yet I'm not sure how many good libraries for this there are or if Mojang has something that could be used
- [x] `URLDisc`'s custom data
  - ~~I have yet to do this but looking at how the data's structured in an NBT editor I believe I should be able to do this fairly easily with Mojang's systems without breaking existing discs~~ I did it, just like the networking changes there's also more boilerplate (yayy)
  ```java
  // before
  public static final KeyedEndec<String> URL_KEY = new KeyedEndec<>("music_url", Endec.STRING, "");

  tag.put(URL_KEY, url.toString());
  tag.get(URL_KEY);

  // after
  
  // i hate this wrapper just as much as you do
  public static final class DataWrapper {
      public static final String URL_KEY = "music_url";
      public static final String LOCK_KEY = "lock";
      public static final String DURATION_KEY = "duration";
  
      public static void putUrl(CompoundTag tag, String url) {
          tag.put(URL_KEY, StringTag.valueOf(url));
      }
  
      public static void putLock(CompoundTag tag, boolean lock) {
          tag.putBoolean(LOCK_KEY, lock);
      }
  
      public static void putDuration(CompoundTag tag, int duration) {
          tag.putInt(DURATION_KEY, duration);
      }
  
      public static boolean hasDuration(CompoundTag tag) {
          return tag.getInt(DURATION_KEY).isPresent();
      }
  
      public static String getUrl(CompoundTag tag) {
          return tag.getStringOr(URL_KEY, "");
      }
  
      public static boolean getLock(CompoundTag tag) {
          return tag.getBooleanOr(LOCK_KEY, false);
      }
  
      public static int getDuration(CompoundTag tag) {
          return tag.getIntOr(DURATION_KEY, 0);
      }
  }
  
  DataWrapper.putUrl(tag, url.toString());
  DataWrapper.getUrl(tag);
   ```
  - It seems that rather than using [Custom Data Components](https://docs.fabricmc.net/develop/items/custom-data-components) we're just writing directly to `minecraft:custom_data` resulting in the data being laid out like this
  - <img width="631" height="144" alt="image" src="https://github.com/user-attachments/assets/edf870ee-963b-48b5-b7b5-784cd6cd39b6" />
  - I don't *think* this is best practice but as to not break existing discs I think keeping it like this will be fine


I understand that this would require a lot of changes and if you are not willing to accept merge this PR.

(I also just realized this should probably target the `1.21(-1)` branch as it seems you generally do development there then rebase onto newer versions)